### PR TITLE
Env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NOTE: This app talks to our v2 API, documented at [planningcenter.github.io/api-
 
    ```
    bundle install
-   ruby app.rb
+   OAUTH_APP_ID=myclientid OAUTH_SECRET=mysecret ruby app.rb
    ```
 
 4. Visit [localhost:4567](http://localhost:4567).

--- a/app.rb
+++ b/app.rb
@@ -7,15 +7,16 @@ require 'erb'
 require 'time'
 
 class ExampleApp < Sinatra::Base
-  OAUTH_APP_ID = 'app id goes here'
-  OAUTH_SECRET = 'secret goes here'
-  SCOPE = 'people'
+  OAUTH_APP_ID = ENV.fetch('OAUTH_APP_ID').freeze
+  OAUTH_SECRET = ENV.fetch('OAUTH_SECRET').freeze
+  SCOPE = ENV.fetch('SCOPE', 'people').freeze
+  DOMAIN = ENV.fetch('DOMAIN', 'http://localhost:4567').freeze
 
   TOKEN_EXPIRATION_PADDING = 300 # go ahead and refresh a token if it's within
                                  # this many seconds of expiring
 
   enable :sessions
-  set :session_secret, 'super secret - BE SURE TO CHANGE THIS'
+  set :session_secret, ENV.fetch('SESSION_SECRET')
 
   configure :development do
     register Sinatra::Reloader
@@ -68,7 +69,7 @@ class ExampleApp < Sinatra::Base
     # redirect the user to PCO where they can authorize our app
     url = client.auth_code.authorize_url(
       scope: SCOPE,
-      redirect_uri: 'http://localhost:4567/auth/complete'
+      redirect_uri: "#{DOMAIN}/auth/complete"
     )
     redirect url
   end
@@ -77,7 +78,7 @@ class ExampleApp < Sinatra::Base
     # user was redirected back after they authorized our app
     token = client.auth_code.get_token(
       params[:code],
-      redirect_uri: 'http://localhost:4567/auth/complete'
+      redirect_uri: "#{DOMAIN}/auth/complete"
     )
     # store the auth token and refresh token info in our session
     session[:token] = token.to_hash

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,4 @@
+require './app'
+$stdout.sync = true
+run ExampleApp
+


### PR DESCRIPTION
This allows for dead simple deployment to Heroku by adding:
- Environment variables for OAuth configuration (see https://api.planningcenteronline.com/oauth/applications):
  - `OAUTH_APP_ID` - this is the "Client ID"
  - `OAUTH_SECRET` - this is the "Secret"
  - `DOMAIN` - this is the domain of the app
- The `config.ru` is required for starting Sinatra apps the [legacy way](https://github.com/sinatra/sinatra#using-a-classic-style-application-with-a-configru). This is the way [Heroku](https://devcenter.heroku.com/articles/rack#sinatra) does it.